### PR TITLE
Treat XSD files as non-binary files

### DIFF
--- a/builds/diff_new.php
+++ b/builds/diff_new.php
@@ -131,6 +131,7 @@ $toBuildName = parseBuildName($toBuild['description'])['full'];
 										break;
 									case "blp":
 									case "lua":
+									case "xsd":
 									case "xml":
 									case "sbt":
 									case "toc":

--- a/files/scripts/preview_api.php
+++ b/files/scripts/preview_api.php
@@ -78,7 +78,7 @@ if($type == "ogg"){
 			<div class="tab-pane" id="raw" role="tabpanel" aria-labelledby="raw-tab"><pre style='max-height: 500px;'><code><?=htmlentities($output)?></pre></code></div>
 		</div>
 		<?php
-	}else if($type == "xml" || $type == "lua" || $type == "toc"){
+	}else if($type == "xml" || $type == "xsd" || $type == "lua" || $type == "toc"){
 		echo "<pre style='max-height: 500px;'><code>".htmlentities(file_get_contents($tempfile))."</pre></code>";
 	}else{
 		// dump via hd


### PR DESCRIPTION
XSD files are effectively XML documents, so these shouldn't be treated as binary files from the perspective of previewing their contents or diffing them between builds.

Not sure if these are all the changes that are required; it looks like these are the only two places where file extensions for text files get checked.