### PR TITLE
Add GlobalStrings and SoundKit Enums/Flags

### DIFF
--- a/dbc/js/enums.js
+++ b/dbc/js/enums.js
@@ -713,6 +713,41 @@ const spellEffectName = {
     271: 'APPLY_AREA_AURA_PARTY_NONRANDOM'
 };
 
+const soundkitSoundType = {
+	0: 'Unused/Miscellaneous',
+	1: 'Spells',
+	2: 'UI',
+	3: 'Footsteps',
+	4: 'Weapons/Impact',
+	6: 'Weapons/Miss',
+	7: 'Greetings',
+	8: 'Casting',
+	9: 'Pick Up/Put Down',
+	10: 'NPC Combat',
+	12: 'Errors',
+	13: 'Ambient FX',
+	14: 'Objects',
+	16: 'Death',
+	17: 'NPC Greetings',
+	18: 'Test/Temporary',
+	19: 'Armor/Foley',
+	20: 'Footsteps',
+	21: 'Water/Character',
+	22: 'Water/Liquid',
+	23: 'Tradeskills',
+	24: 'Misc. FX',
+	25: 'Doodads',
+	26: 'Spell Fizzle',
+	27: 'NPC Loops',
+	28: 'Zone Music',
+	29: 'Emotes',
+	30: 'Narration Music',
+	31: 'Narration',
+	50: 'Zone Ambience',
+	52: 'Zone Emitters',
+	53: 'Vehicle'
+};
+
 const charSectionType = {
 	0: 'Skin',
 	1: 'Face',
@@ -763,6 +798,7 @@ enumMap.set("charsections.SexID", charSex);
 enumMap.set("charsectioncondition.BaseSection", charSectionType);
 enumMap.set("charsectioncondition.Sex", charSex);
 enumMap.set("uimap.Type", uiMapType);
+enumMap.set("soundkit.SoundType", soundkitSoundType);
 // Conditional enums
 let conditionalEnums = new Map();
 conditionalEnums.set("itembonus.Value[0]",

--- a/dbc/js/flags.js
+++ b/dbc/js/flags.js
@@ -217,6 +217,11 @@ const soundkitFlags = {
 	0x0800: 'VARY_VOLUME'
 };
 
+const globalstringsFlags ={
+	0x1: 'FRAMEXML',
+	0x2: 'GLUEXML'
+};
+
 window.flagMap = new Map();
 
 flagMap.set("achievement.Flags", achievementFlags);
@@ -241,3 +246,5 @@ flagMap.set("emotes.EmoteFlags", emoteFlags);
 flagMap.set("map.Flags[0]", mapFlags);
 
 flagMap.set("soundkit.Flags", soundkitFlags);
+
+flagMap.set("globalstrings.Flags", globalstringsFlags);

--- a/dbc/js/flags.js
+++ b/dbc/js/flags.js
@@ -209,6 +209,14 @@ const mapFlags = {
 	0x4000000: 'GARRISON'
 }
 
+const soundkitFlags = {
+	0x0001: 'UNK1',
+	0x0020: 'NO_DUPLICATES',
+	0x0200: 'LOOPING',
+	0x0400: 'VARY_PITCH',
+	0x0800: 'VARY_VOLUME'
+};
+
 window.flagMap = new Map();
 
 flagMap.set("achievement.Flags", achievementFlags);
@@ -231,3 +239,5 @@ flagMap.set("difficulty.Flags", difficultyFlags);
 flagMap.set("emotes.EmoteFlags", emoteFlags);
 
 flagMap.set("map.Flags[0]", mapFlags);
+
+flagMap.set("soundkit.Flags", soundkitFlags);


### PR DESCRIPTION
Adds DBC viewer enums/flags support for the following:

* GlobalStrings.Flags
* SoundKit.Flags (Partial support)
* SoundKit.SoundType

For the SoundKit types and flags I've used [this reference](https://wowdev.wiki/DB/SoundEntries). There's a few additional types I've added by guessing from the filenames but they're probably not *perfectly* accurate. GlobalStrings flags are just what I'd noticed from ingame testing a while back.