### PR TITLE
Defined a ChrRaces flag

### DIFF
--- a/dbc/js/flags.js
+++ b/dbc/js/flags.js
@@ -182,6 +182,7 @@ const chrRacesFlags = {
 	0x200 : 'CREATIONUNK',
 	0x400 : 'SELECTIONUNK',
 	0x10000 : 'SKINISHAIRUNK',
+	0x100000 : 'VOID_ELF_RACIAL',
 }
 
 const taxiNodeFlags = {


### PR DESCRIPTION
Only Void Elves have this flag and it's used for taking 50% off void storage/transmog prices.(https://www.wowhead.com/spell=255667/ethereal-connection)