### PR TITLE
Skip empty value for filtered column to prevent duplicate entry

### DIFF
--- a/builds/diff_new.php
+++ b/builds/diff_new.php
@@ -186,6 +186,9 @@ $encrypted = $pdo->query("SELECT filedataid FROM wow_encrypted WHERE keyname NOT
                             });
 
                         column.data().unique().sort().each(function(d, j) {
+                            if(d === "") {
+                                continue;
+                            }
                             select.append('<option value="' + d + '">' + d + '</option>')
                         });
                     } else if (element.hasClass("searchable")) {


### PR DESCRIPTION
Since it both creates an initial empty value, and then further columns can have an "empty value", we skip future cases, to prevent a duplicate entry of nothiningness.