### PR TITLE
Fix color hex value in BGRA2RGBA function

### DIFF
--- a/dbc/js/dbc.js
+++ b/dbc/js/dbc.js
@@ -135,7 +135,7 @@ function dec2hex(str, big = false){
 }
 
 function BGRA2RGBA(color){
-    var hex = dec2hex(color);
+    var hex = dec2hex(color).padStart(6, '0');
 
     for (var bytes = [], c = 0; c < hex.length; c += 2)
     {


### PR DESCRIPTION
A hex color must be 3 or 6 char length otherwise you get wrong color values like here https://wow.tools/dbc/?dbc=lightdata&build=8.3.7.35662#page=1&colFilter[0]=38323 SkyBand1Color: 859722 => #d1e4a => 209,228,10,0