### PR TITLE
Named some chrRacesFlags

### DIFF
--- a/dbc/js/flags.js
+++ b/dbc/js/flags.js
@@ -179,16 +179,18 @@ const charSectionFlags = {
 
 const chrRacesFlags = {
     0x1 : 'NOT_PLAYABLE',
-    0x2 : 'BARE_FEET',
+    0x2 : 'DoNotComponentFeet',
     0x4 : 'CAN_MOUNT',
-    0x8 : 'PLAYABLE_MAYBE',
+    0x8 : 'HasBald',
     0x80 : 'DISALLOW_LOW_RES',
     0x100 : 'GOBLIN_RACIAL',
     0x200 : 'CREATIONUNK',
     0x400 : 'SELECTIONUNK',
-    0x10000 : 'SKINISHAIRUNK',
+    0x800 : 'UseLoincloth',
+    0x10000 : 'SkinVariationIsHairColor',
+    0x20000 : 'UsePandarenRingForComponentingTexture',
     0x80000 : 'ALLIED_RACE',
-    0x100000 : 'VOID_ELF_RACIAL',
+    0x100000 : 'VOID_ELF_RACIAL'
 }
 
 const taxiNodeFlags = {


### PR DESCRIPTION
Defined some more flags in ChrRaces, based on the names shown in the Engineer's Workshop:

- BARE_FEET -> DoNotComponentFeet
Should be pretty self-explanatory.

- PLAYABLE_MAYBE -> HasBald
Races played by Asmongold. Jk, this flag tells the client to copy the male textures defined for the second hair style in CharSections to the first one. The first hairstyle for male characters just so happens to be the bald one. Does not appear in 9.x anymore.

- UseLoincloth
This enables the Loincloth seen on Pandaren Females.

- SKINISHAIRUNK -> SkinVariationIsHairColor
Should also be pretty self-explanatory.

- UsePandarenRingForComponentingTexture
This one is a guess, but seems correct based on order of appearance of the previous flags and the names listed in the workshop. It is also the last flag that's used in all three pandaren races.
