### PR TITLE
SpellEffect.EffectAura value 141 is for hunter quivers

### DIFF
--- a/dbc/js/enums.js
+++ b/dbc/js/enums.js
@@ -1059,7 +1059,7 @@ const effectAuraType = {
     138: 'MOD_MELEE_HASTE',
     139: 'FORCE_REACTION',
     140: 'MOD_RANGED_HASTE',
-    // 141: '141',
+    141: 'MOD_RANGED_HASTE_QUIVER', // Attack speed bonus from quiver/ammo pouch
     142: 'MOD_BASE_RESISTANCE_PCT',
     143: 'MOD_RESISTANCE_EXCLUSIVE',
     144: 'SAFE_FALL',


### PR DESCRIPTION
SpellEffect.EffectAura value 141 is used in 2.5.x and 1.13.x for the attack speed bonus for all and only hunter quivers and ammo pouches. 

```
sqlite> select item.id, spellid, effectaura from item left join itemeffect on item.id = itemeffect.parentitemid left join spelleffect using(spellid) where classid = 11;
1281||
2002|5102|14
2003||
2101|29418|141
2102|14824|141
2662|29415|141
2663|14828|141
3573|29418|141
3574|14824|141
3604|14825|141
3605|29417|141
5439|29418|141
5441|14824|141
7278|29418|141
7279|14824|141
7371|29416|141
7372|14826|141
8217|29413|141
8218|14827|141
11362|29418|141
11363|14824|141
18714|29414|141
19319|29414|141
19320|14829|141
29118|14829|141
29143|29414|141
29144|29414|141
29889|29414|141
34099|14829|141
34100|29414|141
34105|29414|141
34106|14829|141
```

Note the top three results above are test items not available in-game.


```
sqlite> select ParentItemID, display_lang from itemeffect left join spelleffect using (spellid) left join itemsparse on itemsparse.id = parentitemid where EffectAura = 141;
11363|Medium Shot Pouch
2102|Small Ammo Pouch
3574|Hunting Ammo Sack
5441|Small Shot Pouch
7279|Small Leather Ammo Pouch
3604|Bandolier of the Night Watch
7372|Heavy Leather Ammo Pouch
8218|Thick Leather Ammo Pouch
2663|Ribbly's Bandolier
19320|Gnoll Skin Bandolier
29118|Smuggler's Ammo Pouch
34099|Knothide Ammo Pouch
34106|Netherscale Ammo Pouch
2662|Ribbly's Quiver
7371|Heavy Quiver
3605|Quiver of the Night Watch
11362|Medium Quiver
2101|Light Quiver
3573|Hunting Quiver
5439|Small Quiver
7278|Light Leather Quiver
8217|Quickdraw Quiver
18714|Ancient Sinew Wrapped Lamina
19319|Harpy Hide Quiver
29143|Clefthoof Hide Quiver
29144|Worg Hide Quiver
29889|Hunter 105/150 Epic Test Ammo Pouch
34100|Knothide Quiver
34105|Quiver of a Thousand Feathers
```