### PR TITLE
garrAutoSpellEffectType and garrAutoSpellEffectTargetType corrections

### DIFF
--- a/dbc/js/enums.js
+++ b/dbc/js/enums.js
@@ -4633,15 +4633,15 @@ const garrAutoSpellEffectType = {
     9: 'Taunt', // TAUNT
     10: 'Detaunt', // DETAUNT
     11: 'Mod Damage Done', // MOD_DAMAGE_DONE
-    12: 'Mod Damage Done %', // MOD_DAMAGE_DONE_PCT
+    12: 'Mod Damage Done %', // MOD_DAMAGE_DONE_PCT_ONLY
     13: 'Mod Damage Taken', // MOD_DAMAGE_TAKEN
-    14: 'Mod Damage Taken %', // MOD_DAMAGE_TAKEN_PCT
+    14: 'Mod Damage Taken %', // MOD_DAMAGE_TAKEN_PCT_ONLY
     15: 'Deal Damage to Attacker', // DEAL_DAMAGE_TO_ATTACKER
     16: 'Deal Damage to Attacker %', // DEAL_DAMAGE_TO_ATTACKER_PCT
     17: 'Incease Max Health', // INCREASE_MAX_HEALTH
     18: 'Increase Max Health %', // INCREASE_MAX_HEALTH_PCT
-    19: 'MOD_DAMAGE_DONE_PCT_OF_FLAT',
-    20: 'MOD_DAMAGE_TAKEN_PCT_OF_FLAT',
+    19: 'Mod Damage Done %', // MOD_DAMAGE_DONE_PCT
+    20: 'Mod Damage Taken %', // MOD_DAMAGE_TAKEN_PCT
 }
 
 // 1034
@@ -4666,9 +4666,11 @@ const garrAutoSpellEffectTargetType = {
     17: 'All Back Row Hostiles', // ALL_BACK_ROW_HOSTILES
     18: 'All Targets', // ALL_TARGETS
     19: 'Random Target', // RANDOM_TARGET
-    20: 'Random Ally', // RANDOM_ALLY
-    21: 'Random Enemy', // RANDOM_ENEMY
-    22: 'ALL_FRIENDLIES_BUT_SELF',
+    20: 'Random Follower', // RANDOM_FOLLOWER
+    21: 'Random Encounter', // RANDOM_ENCOUNTER
+    22: 'All Other Friendlies', // ALL_FRIENDLIES_BUT_SELF
+    23: 'All Followers', // ALL_FOLLOWERS
+    24: 'All Encounters', // ALL_ENCOUNTERS
 }
 
 // 1049

--- a/dbc/js/enums.js
+++ b/dbc/js/enums.js
@@ -4633,9 +4633,9 @@ const garrAutoSpellEffectType = {
     9: 'Taunt', // TAUNT
     10: 'Detaunt', // DETAUNT
     11: 'Mod Damage Done', // MOD_DAMAGE_DONE
-    12: 'Mod Damage Done %', // MOD_DAMAGE_DONE_PCT_ONLY
+    12: 'Mod Damage Done % (points only)', // MOD_DAMAGE_DONE_PCT_POINTS_ONLY
     13: 'Mod Damage Taken', // MOD_DAMAGE_TAKEN
-    14: 'Mod Damage Taken %', // MOD_DAMAGE_TAKEN_PCT_ONLY
+    14: 'Mod Damage Taken % (points only)', // MOD_DAMAGE_TAKEN_PCT_POINTS_ONLY
     15: 'Deal Damage to Attacker', // DEAL_DAMAGE_TO_ATTACKER
     16: 'Deal Damage to Attacker %', // DEAL_DAMAGE_TO_ATTACKER_PCT
     17: 'Incease Max Health', // INCREASE_MAX_HEALTH


### PR DESCRIPTION
Corrections to fix the below issues.

`garrAutoSpellEffectType`:
1. All `*_PCT` commented values switch behaviour between percentage and percentage of attack, when the flag `garrAutoSpellEffectFlags[0x1]` is present, except for `12` & `13`. These two are always only a percentage from the points value, and ignore the flag entirely. `19` & `20` having the comment `*_PCT_OF_FLAT` is not a description unique to their behaviour anymore than `*_PCT` is for the others, and creates the misconception they behave differently to others. These two are the ones that match the `*_PCT` behaviour of others, while `19` & `20` don't.
2. `18` & `19` don't have proper values, and they should just be what `12` & `13` are.
3. `12` & `13` need new values and comments to reflect their unique behaviour.

`garrAutoSpellEffectTargetType`:
1. The values and comments for `20` & `21` don't match their behaviour. These are for follower and encounter respectively, not friendly and enemy.
2. `22` doesn't have a proper value, and its current value should be the comment.
3. Entries for `23` & `24` are missing.